### PR TITLE
Use "static" instead of "object" for PHPStorm autocomplete support.

### DIFF
--- a/src/php/FlorianWolters/Component/Util/Singleton/MultitonTrait.php
+++ b/src/php/FlorianWolters/Component/Util/Singleton/MultitonTrait.php
@@ -23,7 +23,7 @@ trait MultitonTrait
      * @staticvar object[] $instances The *Multiton* instances of the classes
      *                                using this trait.
      *
-     * @return object The *Multiton* instance.
+     * @return static The *Multiton* instance.
      */
     public static function getInstance()
     {

--- a/src/php/FlorianWolters/Component/Util/Singleton/SingletonTrait.php
+++ b/src/php/FlorianWolters/Component/Util/Singleton/SingletonTrait.php
@@ -22,7 +22,7 @@ trait SingletonTrait
      * @staticvar object[] $instances The *Singleton* instances of the classes
      *                                using this trait.
      *
-     * @return object The *Singleton* instance.
+     * @return static The *Singleton* instance.
      */
     final public static function getInstance()
     {


### PR DESCRIPTION
I was recently working with this class when I discovered PHPStorm wasn't showing autocomplete for anything after the `getInstance` call on any class that used the singleton classes. As it was very annoying, I set out to fix it. It turns out, PHPStorm supports the "static" object type, representing an instance of the current class as one might expect.

I merely updated the PHPDoc blocks to use static instead of object so that autocomplete will be better supported.
